### PR TITLE
Mapped 'SICP' to 'Necronomicon'

### DIFF
--- a/fluffify/data/dictionary.json
+++ b/fluffify/data/dictionary.json
@@ -48,5 +48,6 @@
     "return on investment": "extra monies",
     "roi": "extra monies",
     "wifi": "invisible cables",
-    "cto": "Head Nerd"
+    "cto": "Head Nerd",
+    "SICP": "Necronomicon"
 }


### PR DESCRIPTION
Because *why not*?
I mean it **is** The Wizard Book.
"This book is dedicated, in respect and admiration, to the spirit that lives in the computer." -[SICP](http://mitpress.mit.edu/sicp/full-text/book/book-Z-H-3.html)